### PR TITLE
Add link to qalculate-qt on Homebrew

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -74,7 +74,8 @@ Most distributions for Linux provide packages (which may or may not be outdated)
 <div class="sectiontitle">Mac OS binaries:</div>
 <ul>
 <li><a href="https://ports.macports.org/search/?q=qalculate">Qalculate! at MacPorts</a></li>
-<li><a href="https://formulae.brew.sh/formula/qalculate-gtk">Qalculate! Homebrew Formulae</a></li>
+<li><a href="https://formulae.brew.sh/formula/qalculate-gtk">Qalculate! Homebrew Formulae (GTK UI)</a></li>
+<li><a href="https://formulae.brew.sh/formula/qalculate-qt">Qalculate! Homebrew Formulae (Qt UI)</a></li>
 </ul>
 <hr>
 <div class="sectiontitle">Source code:</div>


### PR DESCRIPTION
`qalculate-qt` is now available on Homebrew for easy installation on MacOS. See PR: https://github.com/Homebrew/homebrew-core/pull/145585

This PR adds a link to the new Homebrew formula: https://formulae.brew.sh/formula/qalculate-qt