### PR TITLE
Fix screenshot overflow in mobile view and cleanup css

### DIFF
--- a/css/qalculate.css
+++ b/css/qalculate.css
@@ -28,9 +28,6 @@
 	border-radius: 0.35em;
 }
 
-.navleave {
-}
-
 .navitem:hover {
 	background-color: #333A40;
 	transition: 0.3s;
@@ -330,9 +327,6 @@
 .button:hover {
 	background-color: #cc4499;
 	transition: background-color 0.5s;
-}
-
-.whiteimage {
 }
 
 @media (prefers-color-scheme: dark) {

--- a/css/qalculate.css
+++ b/css/qalculate.css
@@ -218,6 +218,10 @@
 		font-family: sans-serif;
 		text-transform: uppercase;
 	}
+
+	.screenshots {
+		height: auto;
+	}
 }
 
 @media only screen and (min-width: 750px) {
@@ -364,3 +368,9 @@ ul {
 	 margin: 0.5em 0;
 }
 
+.screenshots {
+	width: 100%;
+	aspect-ratio: 4 / 3;
+	object-fit: contain;
+	display: block;
+}

--- a/screenshots.html
+++ b/screenshots.html
@@ -64,7 +64,7 @@
 <br><br>
 <a href="images/qalculate-plot.png"><IMG src="images/qalculate-plot.png" width="378" height="450" border="0"></a>
 <br><br>
-<IMG src="images/qalc.png" width="621" height="497" border="0">
+<a href="images/qalc.png"><IMG src="images/qalc.png" width="621" height="497" border="0"></a>
 </div>
 </div>
 </div>

--- a/screenshots.html
+++ b/screenshots.html
@@ -44,27 +44,27 @@
 <div class="content">
 <br>
 <div style="text-align: center;">
-<a href="images/qalculate-main-window.png"><IMG src="images/qalculate-main-window.png" width="427" height="203" border="0"></a>
+<a href="images/qalculate-main-window.png"><IMG class="screenshots" src="images/qalculate-main-window.png" width="427" height="203" border="0"></a>
 <br><br>
-<a href="images/qalculate-history.png"><IMG src="images/qalculate-history.png" width="567" height="567" border="0"></a>
+<a href="images/qalculate-history.png"><IMG class="screenshots" src="images/qalculate-history.png" width="567" height="567" border="0"></a>
 <br><br>
-<a href="images/qalculate-keypad.png"><IMG src="images/qalculate-keypad.png" width="581" height="445" border="0"></a>
+<a href="images/qalculate-keypad.png"><IMG class="screenshots" src="images/qalculate-keypad.png" width="581" height="445" border="0"></a>
 <br><br>
-<a href="images/qalculate-qt.png"><IMG src="images/qalculate-qt.png" width="552" height="555" border="0"></a>
+<a href="images/qalculate-qt.png"><IMG class="screenshots" src="images/qalculate-qt.png" width="552" height="555" border="0"></a>
 <br><br>
-<a href="images/qalculate-programming.png"><IMG src="images/qalculate-programming.png" width="572" height="428" border="0"></a>
+<a href="images/qalculate-programming.png"><IMG class="screenshots" src="images/qalculate-programming.png" width="572" height="428" border="0"></a>
 <br><br>
-<a href="images/qalculate-conversion.png"><IMG src="images/qalculate-conversion.png" width="525" height="488" border="0"></a>
+<a href="images/qalculate-conversion.png"><IMG class="screenshots" src="images/qalculate-conversion.png" width="525" height="488" border="0"></a>
 <br><br>
-<a href="images/qalculate-insert-function.png"><IMG src="images/qalculate-insert-function.png" width="377" height="401" border="0"></a>
+<a href="images/qalculate-insert-function.png"><IMG class="screenshots" src="images/qalculate-insert-function.png" width="377" height="401" border="0"></a>
 <br><br>
-<a href="images/qalculate-units.png"><IMG src="images/qalculate-units.png" width="618" height="453" border="0"></a>
+<a href="images/qalculate-units.png"><IMG class="screenshots" src="images/qalculate-units.png" width="618" height="453" border="0"></a>
 <br><br>
-<a href="images/qalculate-edit-function.png"><IMG src="images/qalculate-edit-function.png" width="369" height="467" border="0"></a>
+<a href="images/qalculate-edit-function.png"><IMG class="screenshots" src="images/qalculate-edit-function.png" width="369" height="467" border="0"></a>
 <br><br>
-<a href="images/qalculate-plot.png"><IMG src="images/qalculate-plot.png" width="378" height="450" border="0"></a>
+<a href="images/qalculate-plot.png"><IMG class="screenshots" src="images/qalculate-plot.png" width="378" height="450" border="0"></a>
 <br><br>
-<a href="images/qalc.png"><IMG src="images/qalc.png" width="621" height="497" border="0"></a>
+<a href="images/qalc.png"><IMG class="screenshots" src="images/qalc.png" width="621" height="497" border="0"></a>
 </div>
 </div>
 </div>


### PR DESCRIPTION
@hanna-kn  This PR fixes mobile related issues of screenshots and cleans up some css selectors. 

changes:
- wrapped image using an anchor tag for instant viewing on click. 
- fixed screenshot overflow on mobile caused by width issues,  it now use aspect ratio on both large and small screens.
- removed unused css selectors.